### PR TITLE
Background

### DIFF
--- a/app/controllers/api/v1/backgrounds_controller.rb
+++ b/app/controllers/api/v1/backgrounds_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::BackgroundsController < ApplicationController
+  def index
+    render json: BackgroundSerializer.new(
+      BackgroundsFacade.new(params[:location])
+    )
+  end
+end

--- a/app/facades/backgrounds_facade.rb
+++ b/app/facades/backgrounds_facade.rb
@@ -1,0 +1,21 @@
+class BackgroundsFacade
+  attr_reader :id
+
+  def initialize(city_state)
+    @city_state = city_state
+  end
+
+  def image
+    Image.new(image_for(@city_state)[:photos][:photo][0])
+  end
+
+  private
+
+  def image_for(city_state)
+    @_image_for ||= flickr_service.image_by(city_state)
+  end
+
+  def flickr_service
+    FlickrService.new
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,15 @@
+class Image
+  attr_reader :url
+
+  def initialize(attr)
+    @url = farm_url(attr)
+  end
+
+  def farm_url(attr)
+    farm = attr[:farm]
+    server = attr[:server]
+    id = attr[:id]
+    secret = attr[:secret]
+    "https://farm#{farm}.staticflickr.com/#{server}/#{id}_#{secret}.jpg"
+  end
+end

--- a/app/serializers/background_serializer.rb
+++ b/app/serializers/background_serializer.rb
@@ -1,0 +1,4 @@
+class BackgroundSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :image
+end

--- a/app/services/flickr_service.rb
+++ b/app/services/flickr_service.rb
@@ -1,0 +1,25 @@
+class FlickrService
+  def image_by(city_state)
+    get_json("/services/rest/?text=#{city_state}, skyline")
+  end
+
+  private
+
+  def conn
+    Faraday.new(url: "https://www.flickr.com") do |f|
+      f.params['method'] = "flickr.photos.search"
+      f.params['api_key'] = ENV['FLICKR_API_KEY']
+      f.params['geo_context'] = 2
+      f.params['per_page'] = 1
+      f.params['accuracy'] = 10
+      f.params['format'] = 'json'
+      f.params['nojsoncallback'] = 1
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+  def get_json(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'forecast', to: 'forecasts#index'
+      get 'backgrounds', to: 'backgrounds#index'
     end
   end
 end

--- a/fixtures/denver_flickr.json
+++ b/fixtures/denver_flickr.json
@@ -1,0 +1,22 @@
+{
+    "photos": {
+        "page": 1,
+        "pages": 71,
+        "perpage": 1,
+        "total": "71",
+        "photo": [
+            {
+                "id": "43691964192",
+                "owner": "8121206@N07",
+                "secret": "4ff507454d",
+                "server": "930",
+                "farm": 1,
+                "title": "Denver Skyline",
+                "ispublic": 1,
+                "isfriend": 0,
+                "isfamily": 0
+            }
+        ]
+    },
+    "stat": "ok"
+}

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe Image do
+  it "exists" do
+    flickr = File.read("./fixtures/denver_flickr.json")
+    response =  JSON.parse(flickr, symbolize_names: true)
+    attr = response[:photos][:photo][0]
+    image = Image.new(attr)
+
+    expect(image).to be_a Image
+    expect(image.url).to eq("https://farm1.staticflickr.com/930/43691964192_4ff507454d.jpg")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+# require 'webmock/rspec'
 ENV['RAILS_ENV'] ||= 'test'
 require 'simplecov'
 SimpleCov.start

--- a/spec/requests/api/v1/background_image_spec.rb
+++ b/spec/requests/api/v1/background_image_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe 'Backgrounds API' do
+  it "gets an image" do
+    get '/api/v1/backgrounds?location=denver,co'
+
+    expect(response).to be_successful
+    image = JSON.parse(response.body)
+
+    expect(image["data"].count).to eq(3)
+    expect(image["data"]["attributes"]["image"]["url"]).to eq("https://farm1.staticflickr.com/930/43691964192_4ff507454d.jpg")
+  end
+end


### PR DESCRIPTION
This PR exposes the get '/api/v1/backgrounds?location=<location>' endpoint which returns the json of an image. It also follows a different design paradigm that I will stick with throughout the rest of the project. 